### PR TITLE
Added Setter for return as

### DIFF
--- a/application/libraries/Mongo_db.php
+++ b/application/libraries/Mongo_db.php
@@ -208,6 +208,21 @@ Class Mongo_db{
 		}
 	}
 
+    /**
+     * Sets the return as to object or array
+     * This is useful if library is used in another library to avoid issue if config values are different
+     *
+     * @param string $value
+     */
+    public function set_return_as($value)
+    {
+        if(!in_array($value, ['array', 'object']))
+        {
+            show_error("Invalid Return As Type");
+        }
+        $this->return_as = $value;
+    }
+
 	/**
 	* --------------------------------------------------------------------------------
 	* Connect to MongoDB Database


### PR DESCRIPTION
I already mentioned the reasons for this change on previous PR 

This is useful if library is used within other library to avoid conflicts if configuration differs

I'm currently working on porting Ion_Auth to work with MongoDB using this library. It's important that MongoDB always return data as array or otherwise the library will fail. In order to do so I'm initializing the mongo library like this

```
$this->mongo_db = clone $CI->mongo_db;
$this->mongo_db->set_return_as('array');
```

So in such case even if the user modifies the config in $config['mongo_db']['default']['return_as'] to return object there will be no issues in Ion_Auth library as it will always work with arrays

The best approach here will be to return results data as CI_DB_Result but it will require a lot of work to implement as it will require overriding it with mongo_result class and setting sort of various parameters